### PR TITLE
Run unit tests and obtain code coverage in github action

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,49 @@
+name: Unit test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - 'v*-branch'
+  push:
+    branches:
+      - main
+      - 'v*-branch'
+    tags:
+      - v*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+        with:
+          path: ncs/nrf
+          fetch-depth: 0
+
+      - name: West init and update
+        uses: docker://nrfassettracker/nrfconnect-sdk:main
+        with:
+          args: bash -c "cd ncs/nrf && west init -l && west update --narrow -o=--depth=1"
+
+      - name: Run unit tests with twister
+        uses: docker://nrfassettracker/nrfconnect-sdk:main
+        continue-on-error: true
+        with:
+          args: bash -c "apt install -y lcov gcc-multilib && cd ncs/nrf && source ../zephyr/zephyr-env.sh && ../zephyr/scripts/twister -i -C -T ./ -p native_posix"
+
+      - name: Replace docker paths in coverage file
+        run: |
+          sudo sed -i 's/\/github\/workspace\//\/home\/runner\/work\/sdk-nrf\/sdk-nrf\//g' ncs/nrf/twister-out/coverage.info
+
+      - name: Report code coverage
+        uses: zgosalvez/github-actions-report-lcov@v1.4.0
+        with:
+          coverage-files: ncs/nrf/twister-out/coverage.info
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          minimum-coverage: 10
+          artifact-name: code-coverage-report
+          working-directory: ncs/nrf


### PR DESCRIPTION
- Run unit tests in sdk-nrf in github actions
- Generate code coverage and publish the summary as a PR comment.
- Coverage report (html) available as artifact of the job
- Have issues with branch coverage report. Raised it here https://github.com/zgosalvez/github-actions-report-lcov/discussions/17