### PR TITLE
workflow: New workflow to cancel previously running long workflows

### DIFF
--- a/.github/workflows/cancel-previous.yml
+++ b/.github/workflows/cancel-previous.yml
@@ -1,0 +1,14 @@
+name: Cancel previous workflow
+on:
+  workflow_run:
+    # List long running github workflows here.
+    workflows: ["Documentation Build"]
+    types:
+      - requested
+jobs:
+  cancel:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: styfle/cancel-workflow-action@v0.11.0
+      with:
+        workflow_id: ${{ github.event.workflow.id }}


### PR DESCRIPTION
Added a new workflow that cancels any previously running workflow listed under 'workflows' in this file. As of now, this lists the DOcumentation Build alone as that is the longest known github action as on writing this. This should significantly bring down the billable run durations on the sdk-nrf repo.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>