### PR TITLE
workflow: Trigger sonarcloud only on native_posix tests on PR

### DIFF
--- a/.github/workflows/sonarcloud-pr.yml
+++ b/.github/workflows/sonarcloud-pr.yml
@@ -1,15 +1,10 @@
-# Workflow that runs static code analysis using sonarcloud.io.
-name: Sonarcloud analysis
-on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:  # This is added to be able to trigger this manually from github's web UI.
+name: Sonarcloud analysis (Pull Request)
+on: pull_request
 
 jobs:
   build:
     name: Sonar cloud analysis
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     container: nordicplayground/nrfconnect-sdk:main
     env:
       SONAR_SCANNER_VERSION: 4.7.0.2747
@@ -59,11 +54,17 @@ jobs:
           unzip -o $HOME/.sonar/build-wrapper-linux-x86.zip -d $HOME/.sonar/
           echo "$HOME/.sonar/build-wrapper-linux-x86" >> $GITHUB_PATH
 
+      - name: Build native_posix tests with coverage enabled (via sonarcloud build wrapper)
+        shell: bash
+        run: |
+          source ncs/zephyr/zephyr-env.sh
+          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ncs/zephyr/scripts/twister -b -C -v -i -T ncs/nrf/ -p native_posix --coverage-tool gcovr
+
       - name: Run native_posix tests
         shell: bash
         run: |
           source ncs/zephyr/zephyr-env.sh
-          ncs/zephyr/scripts/twister --clobber-output -v -i -C -T ncs/nrf/ -p native_posix --coverage-tool gcovr
+          ncs/zephyr/scripts/twister --test-only -v -i -C -T ncs/nrf/ -p native_posix
 
       # Exclude twister-out because we dont need coverage reports for mocks and generated files.
       # Exclude tests/unity because it is not interesting
@@ -81,13 +82,6 @@ jobs:
             --exclude=ncs/nrf/tests/subsys/dfu/dfu_target_stream/ \
             --exclude=ncs/nrf/lib/hw_id/ \
             --sonarqube coverage.xml
-
-      - name: Invoke build wrapper with twister command to build with integrations scope
-        shell: bash
-        continue-on-error: true # Some samples fail to compile due to missing tools in the docker image.
-        run: |
-          source ncs/zephyr/zephyr-env.sh
-          build-wrapper-linux-x86-64 --out-dir ${{ env.BUILD_WRAPPER_OUT_DIR }} ncs/zephyr/scripts/twister --ninja --integration --board-root ncs/nrf/boards --quarantine-list ncs/nrf/scripts/quarantine.yaml --clobber-output --build-only -v -i -T ncs/nrf
 
       - name: Run sonar-scanner
         env:


### PR DESCRIPTION
Created a new workflow file that runs sonarcloud by only invoking twister for native_posix tests. The sonarcloud analysis on main branch will run twister with integration scope and will take longer time to complete.

Signed-off-by: Balaji Srinivasan <balaji.srinivasan@nordicsemi.no>